### PR TITLE
Firefox is available on Windows on Arm

### DIFF
--- a/src/data/applications/firefox.json
+++ b/src/data/applications/firefox.json
@@ -1,5 +1,5 @@
 {
   "name": "Mozilla Firefox",
-  "armVersion": false,
+  "armVersion": true,
   "link": "https://www.mozilla.org/firefox"
 }


### PR DESCRIPTION
Regular installer just gives you the Arm version. Also available in the ftp since a while, see http://ftp.mozilla.org/pub/firefox/releases/77.0.1/ win64-aarch64.