### PR TITLE
Fix lost whitespace after minification

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,7 +71,7 @@ export default async function Page() {
       </main>
       <footer>
         <p>
-          Made with ❤️ by
+          Made with ❤️ by&#32;
           <a href="https://dstaley.com">Dylan Staley</a>, who dreams of a full
           ARM64 future.
         </p>


### PR DESCRIPTION
The footer text looked mashed together due to minification.